### PR TITLE
#3761: Whitelist LoginPayloadResponse in UpstreamBridge#shouldHandle

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -704,6 +704,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         }
         Preconditions.checkState( future != null, "Unexpected custom LoginPayloadResponse" );
         future.complete( response.getData() );
+
+        // we should never pass this to the backend
+        throw CancelSendSignal.INSTANCE;
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -132,7 +132,7 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public boolean shouldHandle(PacketWrapper packet) throws Exception
     {
-        return con.getServer() != null || packet.packet instanceof PluginMessage || packet.packet instanceof CookieResponse;
+        return con.getServer() != null || packet.packet instanceof PluginMessage || packet.packet instanceof CookieResponse || packet.packet instanceof LoginPayloadResponse;
     }
 
     @Override


### PR DESCRIPTION
Required for #3758 to function correctly.